### PR TITLE
Hotfix/10472 website fix url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.1.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "studio24/frontend": "0.5.*",
+        "studio24/frontend": "0.6.*",
         "symfony/apache-pack": "^1.0",
         "symfony/console": "4.2.*",
         "symfony/dotenv": "4.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -471,16 +471,16 @@
         },
         {
             "name": "studio24/frontend",
-            "version": "v0.5.0",
+            "version": "v0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/studio24/frontend.git",
-                "reference": "d5cc3589e986d90c2b61db5074efd7ec7c9be365"
+                "reference": "47281a41d4c189fe3873e72e7986a9694ef27439"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/studio24/frontend/zipball/d5cc3589e986d90c2b61db5074efd7ec7c9be365",
-                "reference": "d5cc3589e986d90c2b61db5074efd7ec7c9be365",
+                "reference": "47281a41d4c189fe3873e72e7986a9694ef27439",
                 "shasum": ""
             },
             "require": {

--- a/templates/suppliers/show.html.twig
+++ b/templates/suppliers/show.html.twig
@@ -368,11 +368,12 @@
                             <p class="govuk-!-font-size-17featured" itemprop="telephone">{{ supplier.content.phone_number }}</p>
 
                             {# Some URIs are malformed, here we check if a string starts with `http` and if it does, we display something #}
-                            {% if supplier.content.website matches "/^http/" %}
+                            {% if supplier.content.website matches "/@/" %}
+                            {% else %}
                                 <h3 class="govuk-heading-m govuk-!-font-size-17featured govuk-!-margin-0 govuk-!-font-weight-bold">
                                     Website:</h3>
                                 <p class="govuk-!-font-size-17featured break-word">
-                                    <a href="{{ supplier.content.website }}">{{ supplier.content.website }}</a>
+                                    <a href="{{ fix_url(supplier.content.website) }}">{{ supplier.content.website }}</a>
                                 </p>
                             {% endif %}
                             <h3 class="govuk-heading-m govuk-!-font-size-17featured govuk-!-margin-0 govuk-!-font-weight-bold">

--- a/templates/suppliers/show.html.twig
+++ b/templates/suppliers/show.html.twig
@@ -368,7 +368,7 @@
                             <p class="govuk-!-font-size-17featured" itemprop="telephone">{{ supplier.content.phone_number }}</p>
 
                             {# Some URIs are malformed, here we check if a string starts with `http` and if it does, we display something #}
-                            {% if supplier.content.website matches "/@/" %}
+                            {% if supplier.content.website == "" or supplier.content.website matches "/@/" %}
                             {% else %}
                                 <h3 class="govuk-heading-m govuk-!-font-size-17featured govuk-!-margin-0 govuk-!-font-weight-bold">
                                     Website:</h3>


### PR DESCRIPTION
Updating of CCS frontend package to 0.6.0, allowing the use of the fix_url Twig function, along with corresponding template adjustments, to allow the correct displaying of the website field on suppliers.

CCS have approved the change, and say it looks good on UAT, however I'd appreciate some extra confirmation given the additional risk having updated the entire frontend. :)