### PR TITLE
WEB-1264 Removing White line from side of page

### DIFF
--- a/assets/styles/components/_intro_and_description.scss
+++ b/assets/styles/components/_intro_and_description.scss
@@ -3,6 +3,7 @@
 \*------------------------------------*/
 
 .intro_and_description {
+    overflow: hidden; 
 
 }
 

--- a/assets/styles/components/_subcategories.scss
+++ b/assets/styles/components/_subcategories.scss
@@ -5,6 +5,7 @@
 
 .subcategories {
 	.greyed-bg {
+		overflow: hidden; 
 		//padding: 4% 4% 5% 4%;
 	}
 }


### PR DESCRIPTION
hidden overflow of larger divs to prevent white-space on right hand side of sprint 2 page for mobiles and tablets 