### PR TITLE
Web 1412 set cookies to default opt out

### DIFF
--- a/assets/scripts/libraries/cookies-opt-in.js
+++ b/assets/scripts/libraries/cookies-opt-in.js
@@ -374,7 +374,7 @@ var docCookies = {
         var cookieMessageInner = document.createElement('div');
         cookieMessageInner.classList.add('cookie-message__inner', 'govuk-width-container');
         cookieMessageInner.classList.add('site-container');
-        cookieMessageInner.innerHTML = '<div class="cookie-message__intro"><p>We use non-essential cookies to help us improve this website and our services and any data collected is anonymised. Are you happy to help us improve our website and services by allowing us to use cookies on this website?</p></div>';
+        cookieMessageInner.innerHTML = '<div class="cookie-message__intro"><p>We use cookies to collect information about how you use crowncommercial.gov.uk. We use this information to make the website work as well as possible and improve government services.</p></div>';
 
         var optInButton = document.createElement('button');
         optInButton.classList.add('govuk-!-font-size-18', 'govuk-!-font-weight-bold', 'govuk-button', 'gtm--accept-cookies-in-banner');

--- a/assets/scripts/libraries/cookies-opt-in.js
+++ b/assets/scripts/libraries/cookies-opt-in.js
@@ -374,16 +374,17 @@ var docCookies = {
         var cookieMessageInner = document.createElement('div');
         cookieMessageInner.classList.add('cookie-message__inner', 'govuk-width-container');
         cookieMessageInner.classList.add('site-container');
-        cookieMessageInner.innerHTML = '<div class="cookie-message__intro"><p>We use cookies to collect information about how you use crowncommercial.gov.uk. We use this information to make the website work as well as possible and improve government services.</p></div>';
+        cookieMessageInner.innerHTML = '<div class="cookie-message__intro"><p>We use non-essential cookies to help us improve this website and our services and any data collected is anonymised. Are you happy to help us improve our website and services by allowing us to use cookies on this website?</p></div>';
 
         var optInButton = document.createElement('button');
         optInButton.classList.add('govuk-!-font-size-18', 'govuk-!-font-weight-bold', 'govuk-button', 'gtm--accept-cookies-in-banner');
-        optInButton.innerHTML = "Accept cookies";
+        optInButton.innerHTML = "Accept all cookies";
         optInButton.addEventListener('click', optUserIn);
 
         var settingsButton = document.createElement('a');
+        settingsButton.classList.add('govuk-!-font-size-18', 'govuk-!-font-weight-bold', 'govuk-button');
         settingsButton.setAttribute('href', "/cookie-settings");
-        settingsButton.innerHTML = "Cookie settings";
+        settingsButton.innerHTML = "Set cookie preferences";
         // optOutButton.classList.add('button');
         // optOutButton.classList.add('button--tight');
         // optOutButton.classList.add('button--deny');

--- a/assets/scripts/libraries/cookies-opt-in.js
+++ b/assets/scripts/libraries/cookies-opt-in.js
@@ -135,8 +135,8 @@ var docCookies = {
     // Set the default cookies. This JSON Object is saved as the cookie, but we use `initial_cookie_preferences` to maintain structure and various sanity checks
     var cookie_preferences = {
         essentials: true,
-        usage: true,
-        marketing: true,
+        usage: false,
+        marketing: false,
     };
 
 


### PR DESCRIPTION
**Non essential cookies (usage and marketing) should be set to off by default until uses accepts cookies (follows default opt out flow)**

- To test clear cookie data or use incognito mode and navigate to front end site
- cookie banner should appear with new message and 'Set cookie preferences' should now be a button
- Click on cookie preferences to check usage and marketing settings are off by default
- go back to main page and click on accept all cookies
- on cookie settings page, cookies should now be set to on

Cookie banner
<img width="1427" alt="Screenshot 2020-08-19 at 13 56 49" src="https://user-images.githubusercontent.com/69308726/90637494-f88dd980-e223-11ea-99e3-02a99e171a1e.png">

Cookie settings page

<img width="1368" alt="Screenshot 2020-08-19 at 13 57 07" src="https://user-images.githubusercontent.com/69308726/90637511-fcb9f700-e223-11ea-8c4e-73282f2b95bf.png">
