### PR TITLE
Web 392 forms correct validation

### DIFF
--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -96,7 +96,6 @@ class FormController extends AbstractController
         if ($params->get('complaint')) {
             $formData['complaint'] = $params->get('complaint');
         }
-        dump($params);
         // check for submitted data
         if (!empty($formData)) {
             $formErrors = $this->validateForm($formData);

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -77,7 +77,7 @@ class FormController extends AbstractController
         
         // form data used for validation and to remember values when user submits form
         $formData = [
-            'name' => $params->get('name'),    
+            'name' => $params->get('name'),
             'email' => $params->get('email'),
             'phone' => $params->get('phone'),
             'company' => $params->get('company'),
@@ -91,7 +91,7 @@ class FormController extends AbstractController
             $formErrors = $this->validateForm($formData);
 
             // if there are errors re-render contact form with errors and form values
-            if($formErrors) {
+            if ($formErrors) {
                 return $this->render('forms/22-contact.html.twig', [
                     'formErrors' => $formErrors,
                     'formData' => $formData,
@@ -113,10 +113,7 @@ class FormController extends AbstractController
                     return $this->redirectToRoute('form_contact_thanks_complaint');
                 }
             }
-           
-        } 
-        
-       
+        }
     }
 
     public function validateForm(array $data)
@@ -156,11 +153,11 @@ class FormController extends AbstractController
 
         // name
         if (empty($data['name'])) {
-            $errorMessages['nameErr']['errors'][] = 'Enter your name'; 
+            $errorMessages['nameErr']['errors'][] = 'Enter your name';
         }
 
         if (strlen($data['name']) > 80) {
-            $errorMessages['nameErr']['errors'][] = 'Name must be 80 characters or fewer'; 
+            $errorMessages['nameErr']['errors'][] = 'Name must be 80 characters or fewer';
         }
 
         // email
@@ -169,7 +166,7 @@ class FormController extends AbstractController
         }
 
         if (strlen($data['email']) > 80) {
-            $errorMessages['emailErr']['errors'][] = 'Email address must be 80 characters or fewer'; 
+            $errorMessages['emailErr']['errors'][] = 'Email address must be 80 characters or fewer';
         }
         
         // phone
@@ -178,7 +175,7 @@ class FormController extends AbstractController
         }
 
         if (strlen($data['phone']) > 20) {
-            $errorMessages['phoneErr']['errors'][] = 'Telephone number must be 20 characters or fewer'; 
+            $errorMessages['phoneErr']['errors'][] = 'Telephone number must be 20 characters or fewer';
         }
 
         // company
@@ -187,7 +184,7 @@ class FormController extends AbstractController
         }
 
         if (strlen($data['company']) > 80) {
-            $errorMessages['companyErr']['errors'][] = 'Organisation must be 80 characters or fewer'; 
+            $errorMessages['companyErr']['errors'][] = 'Organisation must be 80 characters or fewer';
         }
 
         // job title
@@ -196,7 +193,7 @@ class FormController extends AbstractController
         }
 
         if (strlen($data['jobTitle']) > 100) {
-            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 100 characters or fewer'; 
+            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 100 characters or fewer';
         }
 
         // postcode
@@ -205,7 +202,7 @@ class FormController extends AbstractController
         }
 
         if (strlen($data['postCode']) > 100) {
-            $errorMessages['postCodeErr']['errors'][] = 'Postcode must be 100 characters or fewer'; 
+            $errorMessages['postCodeErr']['errors'][] = 'Postcode must be 100 characters or fewer';
         }
 
         // more detail
@@ -214,14 +211,12 @@ class FormController extends AbstractController
         }
 
         // loop through and check for errors
-       foreach($errorMessages as $type => $value) {
-           if (!empty($errorMessages[$type]['errors'])) {
-               return $errorMessages;
-           }
-       }
+        foreach ($errorMessages as $type => $value) {
+            if (!empty($errorMessages[$type]['errors'])) {
+                return $errorMessages;
+            }
+        }
 
-       return false;
+        return false;
     }
 }
-
-

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -77,20 +77,20 @@ class FormController extends AbstractController
         
         // form data used for validation and to remember values when user submits form
         $formData = [
-            'name' => $params->get('name'),
+            'name' => $params->get('name'),    
             'email' => $params->get('email'),
             'phone' => $params->get('phone'),
             'company' => $params->get('company'),
             'jobTitle' => $params->get('00Nb0000009IXEs'),
             'postCode' => $params->get('post-code'),
-            'moreDetail' => $params->get('more-detail'),
+            'moreDetail' =>  $params->get('more-detail'),
         ];
 
         // check for submitted data
         if (!empty($formData)) {
             $formErrors = $this->validateForm($formData);
 
-            // if there are errors re-render form with errors and form values
+            // if there are errors re-render contact form with errors and form values
             if($formErrors) {
                 return $this->render('forms/22-contact.html.twig', [
                     'formErrors' => $formErrors,
@@ -121,75 +121,106 @@ class FormController extends AbstractController
 
     public function validateForm(array $data)
     {
-        $errorMessages = array();
+        $errorMessages = [
+            'nameErr' => [
+                'errors' => [],
+                'link' => '#name',
+            ],
+            'emailErr' => [
+                'errors' => [],
+                'link' => '#email',
+            ],
+            'phoneErr' => [
+                'errors' => [],
+                'link' => '#phone',
+            ],
+            'companyErr' => [
+                'errors' => [],
+                'link' => '#company',
+            ],
+            'jobTitleErr' => [
+                'errors' => [],
+                'link' => '#00Nb0000009IXEs',
+            ],
+            'postCodeErr' => [
+                'errors' => [],
+                'link' => '#post-code',
+            ],
+            'moreDetailErr' => [
+                'errors' => [],
+                'link' => '#more-detail',
+            ],
+        ];
 
         // validation
 
         // name
         if (empty($data['name'])) {
-            $errorMessages['nameErr'][0] = 'Enter your name'; 
+            $errorMessages['nameErr']['errors'][] = 'Enter your name'; 
         }
 
         if (strlen($data['name']) > 80) {
-            $errorMessages['nameErr'][1] = 'Name must be 80 characters or fewer'; 
+            $errorMessages['nameErr']['errors'][] = 'Name must be 80 characters or fewer'; 
         }
 
         // email
         if (empty($data['email']) || !filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errorMessages['emailErr'][0] = 'Enter an email address in the correct format, like name@example.com';
+            $errorMessages['emailErr']['errors'][] = 'Enter an email address in the correct format, like name@example.com';
         }
 
         if (strlen($data['email']) > 80) {
-            $errorMessages['emailErr'][1] = 'Email address must be 80 characters or fewer'; 
+            $errorMessages['emailErr']['errors'][] = 'Email address must be 80 characters or fewer'; 
         }
         
         // phone
         if (empty($data['phone'])) {
-            $errorMessages['phoneErr'][0] = 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192';
+            $errorMessages['phoneErr']['errors'][] = 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192';
         }
 
         if (strlen($data['phone']) > 20) {
-            $errorMessages['phoneErr'][1] = 'Telephone number must be 20 characters or fewer'; 
+            $errorMessages['phoneErr']['errors'][] = 'Telephone number must be 20 characters or fewer'; 
         }
 
         // company
         if (empty($data['company'])) {
-            $errorMessages['companyErr'][0] = 'Enter an organisation';
+            $errorMessages['companyErr']['errors'][] = 'Enter an organisation';
         }
 
         if (strlen($data['company']) > 80) {
-            $errorMessages['companyErr'][1] = 'Organisation must be 80 characters or fewer'; 
+            $errorMessages['companyErr']['errors'][] = 'Organisation must be 80 characters or fewer'; 
         }
 
         // job title
         if (empty($data['jobTitle'])) {
-            $errorMessages['jobTitleErr'][0] = 'Enter a job title';
+            $errorMessages['jobTitleErr']['errors'][] = 'Enter a job title';
         }
 
         if (strlen($data['jobTitle']) > 100) {
-            $errorMessages['jobTitleErr'][1] = 'Job title must be 100 characters or fewer'; 
+            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 100 characters or fewer'; 
         }
 
         // postcode
         if (empty($data['postCode'])) {
-            $errorMessages['postCodeErr'][0] = 'Enter a postcode';
+            $errorMessages['postCodeErr']['errors'][] = 'Enter a postcode';
         }
 
         if (strlen($data['postCode']) > 100) {
-            $errorMessages['postCodeErr'][1] = 'Postcode must be 100 characters or fewer'; 
+            $errorMessages['postCodeErr']['errors'][] = 'Postcode must be 100 characters or fewer'; 
         }
 
         // more detail
         if (empty($data['moreDetail'])) {
-            $errorMessages['moreDetailErr'][0] = 'Enter more detail';
+            $errorMessages['moreDetailErr']['errors'][] = 'Enter more detail';
         }
 
-        // if there are errors
-        if (!empty($errorMessages)) {
-            return $errorMessages;
-        } else {
-            return false;
-        }
+        // loop through and check for errors
+       foreach($errorMessages as $type => $value) {
+           if (!empty($errorMessages[$type]['errors'])) {
+               return $errorMessages;
+           }
+       }
+
+       return false;
     }
 }
 

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -77,24 +77,24 @@ class FormController extends AbstractController
         
         // form data used for validation and to remember values when user submits form
         $formData = [
-            'enquiryType' => $params->get('origin'),
-            'name' => $params->get('name'),
-            'email' => $params->get('email'),
-            'phone' => $params->get('phone'),
-            'company' => $params->get('company'),
-            'jobTitle' => $params->get('00Nb0000009IXEs'),
-            'postCode' => $params->get('post-code'),
-            'moreDetail' =>  $params->get('more-detail'),
+            'enquiryType' => $params->get('origin', null),
+            'name' => $params->get('name', null),
+            'email' => $params->get('email', null),
+            'phone' => $params->get('phone', null),
+            'company' => $params->get('company', null),
+            'jobTitle' => $params->get('00Nb0000009IXEs', null),
+            'postCode' => $params->get('post-code', null),
+            'moreDetail' =>  $params->get('more-detail', null),
         ];
         
         // check if callback checkbox has been set and add to form data
         if ($params->get('00Nb0000009IXEg') == '1') {
-            $formData['callback'] = $params->get('00Nb0000009IXEg');
+            $formData['callback'] = $params->get('00Nb0000009IXEg', null);
         }
 
         // check if complaint type exists and add to form data
         if ($params->get('complaint')) {
-            $formData['complaint'] = $params->get('complaint');
+            $formData['complaint'] = $params->get('complaint', null);
         }
         // check for submitted data
         if (!empty($formData)) {
@@ -180,10 +180,6 @@ class FormController extends AbstractController
         }
         
         // phone
-        if (empty($data['phone'])) {
-            $errorMessages['phoneErr']['errors'][] = 'Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192';
-        }
-
         if (strlen($data['phone']) > 20) {
             $errorMessages['phoneErr']['errors'][] = 'Telephone number must be 20 characters or fewer';
         }
@@ -202,14 +198,11 @@ class FormController extends AbstractController
             $errorMessages['jobTitleErr']['errors'][] = 'Enter a job title';
         }
 
-        if (strlen($data['jobTitle']) > 100) {
-            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 100 characters or fewer';
+        if (strlen($data['jobTitle']) > 80) {
+            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 80 characters or fewer';
         }
 
         // postcode
-        if (empty($data['postCode'])) {
-            $errorMessages['postCodeErr']['errors'][] = 'Enter a postcode';
-        }
 
         if (strlen($data['postCode']) > 100) {
             $errorMessages['postCodeErr']['errors'][] = 'Postcode must be 100 characters or fewer';

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -77,6 +77,7 @@ class FormController extends AbstractController
         
         // form data used for validation and to remember values when user submits form
         $formData = [
+            'enquiryType' => $params->get('origin'),
             'name' => $params->get('name'),
             'email' => $params->get('email'),
             'phone' => $params->get('phone'),
@@ -85,7 +86,17 @@ class FormController extends AbstractController
             'postCode' => $params->get('post-code'),
             'moreDetail' =>  $params->get('more-detail'),
         ];
+        
+        // check if callback checkbox has been set and add to form data
+        if ($params->get('00Nb0000009IXEg') == '1') {
+            $formData['callback'] = $params->get('00Nb0000009IXEg');
+        }
 
+        // check if complaint type exists and add to form data
+        if ($params->get('complaint')) {
+            $formData['complaint'] = $params->get('complaint');
+        }
+        dump($params);
         // check for submitted data
         if (!empty($formData)) {
             $formErrors = $this->validateForm($formData);

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -163,54 +163,57 @@ class FormController extends AbstractController
 
         // name
         if (empty($data['name'])) {
-            $errorMessages['nameErr']['errors'][] = 'Enter your name';
+            $errorMessages['nameErr']['errors'][0] = 'Enter your name';
         }
 
         if (strlen($data['name']) > 80) {
-            $errorMessages['nameErr']['errors'][] = 'Name must be 80 characters or fewer';
+            $errorMessages['nameErr']['errors'][0] = 'Name must be 80 characters or fewer';
         }
 
         // email
         if (empty($data['email']) || !filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errorMessages['emailErr']['errors'][] = 'Enter an email address in the correct format, like name@example.com';
+            $errorMessages['emailErr']['errors'][0] = 'Enter an email address in the correct format, like name@example.com';
         }
 
         if (strlen($data['email']) > 80) {
-            $errorMessages['emailErr']['errors'][] = 'Email address must be 80 characters or fewer';
+            $errorMessages['emailErr']['errors'][0] = 'Email address must be 80 characters or fewer';
         }
         
         // phone
+        if (empty($data['phone'])) {
+            $errorMessages['phoneErr']['errors'][0] = 'Enter a phone number';
+        }
         if (strlen($data['phone']) > 20) {
-            $errorMessages['phoneErr']['errors'][] = 'Telephone number must be 20 characters or fewer';
+            $errorMessages['phoneErr']['errors'][0] = 'Telephone number must be 20 characters or fewer';
         }
 
         // company
         if (empty($data['company'])) {
-            $errorMessages['companyErr']['errors'][] = 'Enter an organisation';
+            $errorMessages['companyErr']['errors'][0] = 'Enter an organisation';
         }
 
         if (strlen($data['company']) > 80) {
-            $errorMessages['companyErr']['errors'][] = 'Organisation must be 80 characters or fewer';
+            $errorMessages['companyErr']['errors'][0] = 'Organisation must be 80 characters or fewer';
         }
 
         // job title
         if (empty($data['jobTitle'])) {
-            $errorMessages['jobTitleErr']['errors'][] = 'Enter a job title';
+            $errorMessages['jobTitleErr']['errors'][0] = 'Enter a job title';
         }
 
         if (strlen($data['jobTitle']) > 80) {
-            $errorMessages['jobTitleErr']['errors'][] = 'Job title must be 80 characters or fewer';
+            $errorMessages['jobTitleErr']['errors'][0] = 'Job title must be 80 characters or fewer';
         }
 
         // postcode
 
         if (strlen($data['postCode']) > 100) {
-            $errorMessages['postCodeErr']['errors'][] = 'Postcode must be 100 characters or fewer';
+            $errorMessages['postCodeErr']['errors'][0] = 'Postcode must be 100 characters or fewer';
         }
 
         // more detail
         if (empty($data['moreDetail'])) {
-            $errorMessages['moreDetailErr']['errors'][] = 'Enter more detail';
+            $errorMessages['moreDetailErr']['errors'][0] = 'Enter more detail';
         }
 
         // loop through and check for errors

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -91,7 +91,7 @@
 
                     <!-- form -->
                     {# For Twig global variables see config/packages/<environment>/twig.yaml #}
-                    <form class="govuk-!-width-three-quarters" action="/contact/sendToSalesforce" method="POST">
+                    <form class="govuk-!-width-three-quarters" action="/contact/sendToSalesforce" method="POST" novalidate>
 
                         {# Change these field types to hidden for Production #}
                         <input type="hidden" name="orgid" value="{{ web_to_case_orgid }}">
@@ -157,16 +157,29 @@
                         {# wrapper class for error states; `govuk-form-group--error`  #}
                         <div class="govuk-form-group --govuk-form-group--error">
                             <label class="govuk-label" for="name">Name</label>
-                            {#<span id="full-name-error" class="govuk-error-message">#}
+
+                            {% if formErrors.nameErr is defined %}
+                                {% for error in formErrors.nameErr %}
+                                    <span id="full-name-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}
+                            {% endif %}
+
                             {#Descriptive and helpful error message#}
-                            {#</span>#}
+                            {#</span>
                             {# input class for error states; `govuk-input--error`  #}
-                            <input class="govuk-input --govuk-input--error" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text"/>
+                            <input class="govuk-input --govuk-input--error" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text" value="{{formErrors is defined ? formData.name}}"/>
                         </div>
                         <div class="govuk-form-group">
                             <label class="govuk-label" for="email">
                                 Email </label>
-                            <input class="govuk-input" id="email" maxlength="80" name="email" size="20" type="email" required/>
+
+                            {% if formErrors.emailErr is defined %}
+                                {% for error in formErrors.emailErr %}
+                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                         
+                            {% endif %}    
+
+                            <input class="govuk-input" id="email" maxlength="80" name="email" size="20" type="email" value="{{formErrors is defined ? formData.email}}" required/>
                         </div>
 
 
@@ -189,24 +202,52 @@
                         <div class="govuk-form-group">
                             <label class="govuk-label" for="phone"> Telephone
                                 number</label>
-                            <input class="govuk-input" id="phone" maxlength="40" name="phone" size="20" type="text" required/>
+
+                            {% if formErrors.phoneErr is defined %}
+                                {% for error in formErrors.phoneErr %}
+                                    <span id="phone-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                           
+                            {% endif %}
+
+                            <input class="govuk-input" id="phone" maxlength="40" name="phone" size="20" type="text" value="{{formErrors is defined ? formData.phone}}" required/>
                         </div>
 
 
                         <div class="govuk-form-group">
                             <label class="govuk-label" for="company">
                                 Organisation </label>
-                            <input class="govuk-input" id="company" maxlength="80" name="company" size="20" type="text"/>
+
+                            {% if formErrors.companyErr is defined %}
+                                {% for error in formErrors.companyErr %}
+                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                            
+                            {% endif %}   
+
+                            <input class="govuk-input" id="company" maxlength="80" name="company" size="20" type="text" value="{{formErrors is defined ? formData.company}}"/>
                         </div>
                         <div class="govuk-form-group">
                             <label class="govuk-label" for="00Nb0000009IXEs">
                                 Job title </label>
-                            <input class="govuk-input" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text"/>
+
+                            {% if formErrors.jobTitleErr is defined %}
+                                {% for error in formErrors.jobTitleErr %}
+                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                           
+                            {% endif %} 
+
+                            <input class="govuk-input" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text" value="{{formErrors is defined ? formData.jobTitle}}"/>
                         </div>
                         <div class="govuk-form-group govuk-!-width-one-half">
                             <label class="govuk-label" for="post-code">
                                 Organisation post code </label>
-                            <input class="govuk-input" id="post-code" maxlength="100" name="post-code" size="20" type="text"/>
+
+                            {% if formErrors.postCodeErr is defined %}
+                                {% for error in formErrors.postCodeErr %}
+                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                           
+                            {% endif %} 
+
+                            <input class="govuk-input" id="post-code" maxlength="100" name="post-code" size="20" type="text" value="{{formErrors is defined ? formData.postCode}}"/>
                         </div>
 
 
@@ -243,10 +284,17 @@
                         <div class="govuk-form-group">
                             <label id="more-detail-label" class="govuk-label" for="more-detail">Can
                                 you provide more detail?</label>
+
+                            {% if formErrors.moreDetailErr is defined %}
+                                {% for error in formErrors.moreDetailErr %}
+                                    <span id="more-detail-error" class="govuk-error-message">{{error}}</span>
+                                {% endfor %}                      
+                            {% endif %}
+                            
                             <span id="more-detail-hint" class="govuk-hint">
     Do not include personal or financial information, like your credit card details.
   </span>
-                            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required></textarea>
+                            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
                         </div>
 
                         {# Catch-all field for additional Salesforce data #}

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Contact Crown Commercial Services - CCS{% endblock %}
+{% block title %}{{ formErrors is defined ? 'Error: Contact Crown Commercial Services - CCS' : 'Contact Crown Commercial Services - CCS'}}{% endblock %}
 
 {% block header %}
     {% embed '/includes/header.html.twig' %}
@@ -45,6 +45,20 @@
         <!-- required wrapper 2 -->
         <main id="main-content" role="main" class="govuk-main-wrapper">
 
+            {% if formErrors is defined %}
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                <h2 class="govuk-error-summary__title" id="error-summary-title"> There is a problem</h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                     {% for errorType in formErrors %}
+                        {% for error in errorType.errors %}
+                            <a href={{errorType.link}}><li>{{error}}</li></a>
+                        {% endfor %}
+                     {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
 
             {#<div class="govuk-grid-row">#}
             {#<div class="govuk-grid-column-full">#}
@@ -155,11 +169,11 @@
 
 
                         {# wrapper class for error states; `govuk-form-group--error`  #}
-                        <div class="govuk-form-group {{formErrors.nameErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.nameErr is defined and formErrors.nameErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="name">Name</label>
 
-                            {% if formErrors.nameErr is defined %}
-                                {% for error in formErrors.nameErr %}
+                            {% if formErrors.nameErr is defined and formErrors.nameErr.errors|length > 0 %}
+                                {% for error in formErrors.nameErr.errors %}
                                     <span id="full-name-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}
                             {% endif %}
@@ -167,19 +181,19 @@
                             {#Descriptive and helpful error message#}
                             {#</span>
                             {# input class for error states; `govuk-input--error`  #}
-                            <input class="govuk-input {{formErrors.nameErr is defined ? 'govuk-input--error' : null }}" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text" value="{{formErrors is defined ? formData.name}}" autocomplete="name"/>
+                            <input class="govuk-input {{formErrors.nameErr is defined and formErrors.nameErr.errors|length > 0 ? 'govuk-input--error' : null }}" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text" value="{{formErrors is defined ? formData.name}}" autocomplete="name"/>
                         </div>
-                        <div class="govuk-form-group {{formErrors.emailErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.emailErr.errors is defined and formErrors.emailErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="email">
                                 Email </label>
 
-                            {% if formErrors.emailErr is defined %}
-                                {% for error in formErrors.emailErr %}
+                            {% if formErrors.emailErr is defined and formErrors.emailErr.errors|length > 0 %}
+                                {% for error in formErrors.emailErr.errors %}
                                     <span id="email-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                         
                             {% endif %}    
 
-                            <input class="govuk-input {{formErrors.emailErr is defined ? 'govuk-input--error' : null }}" id="email" maxlength="80" name="email" size="20" type="email" value="{{formErrors is defined ? formData.email}}" autocomplete="email" required/>
+                            <input class="govuk-input {{formErrors.emailErr is defined and formErrors.emailErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="email" maxlength="80" name="email" size="20" type="email" value="{{formErrors is defined ? formData.email}}" autocomplete="email" required/>
                         </div>
 
 
@@ -199,55 +213,55 @@
                                 </div>
                             </fieldset>
                         </div>
-                        <div class="govuk-form-group {{formErrors.phoneErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.phoneErr is defined and formErrors.phoneErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="phone"> Telephone
                                 number</label>
 
-                            {% if formErrors.phoneErr is defined %}
-                                {% for error in formErrors.phoneErr %}
+                            {% if formErrors.phoneErr is defined and formErrors.phoneErr.errors|length > 0 %}
+                                {% for error in formErrors.phoneErr.errors %}
                                     <span id="phone-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                           
                             {% endif %}
 
-                            <input class="govuk-input {{formErrors.phoneErr is defined ? 'govuk-input--error' : null }}" id="phone" maxlength="40" name="phone" size="20" type="text" value="{{formErrors is defined ? formData.phone}}" autocomplete="tel" required/>
+                            <input class="govuk-input {{formErrors.phoneErr is defined and formErrors.phoneErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="phone" maxlength="40" name="phone" size="20" type="text" value="{{formErrors is defined ? formData.phone}}" autocomplete="tel" required/>
                         </div>
 
 
-                        <div class="govuk-form-group {{formErrors.companyErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.companyErr is defined and formErrors.companyErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="company">
                                 Organisation </label>
 
-                            {% if formErrors.companyErr is defined %}
-                                {% for error in formErrors.companyErr %}
+                            {% if formErrors.companyErr is defined and formErrors.companyErr.errors|length > 0 %}
+                                {% for error in formErrors.companyErr.errors %}
                                     <span id="email-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                            
                             {% endif %}   
 
-                            <input class="govuk-input {{formErrors.companyErr is defined ? 'govuk-input--error' : null }}" id="company" maxlength="80" name="company" size="20" type="text" value="{{formErrors is defined ? formData.company}}" autocomplete="organization"/>
+                            <input class="govuk-input {{formErrors.companyErr is defined and formErrors.companyErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="company" maxlength="80" name="company" size="20" type="text" value="{{formErrors is defined ? formData.company}}" autocomplete="organization"/>
                         </div>
-                        <div class="govuk-form-group {{formErrors.jobTitleErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.jobTitleErr is defined and formErrors.jobTitleErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="00Nb0000009IXEs">
                                 Job title </label>
 
-                            {% if formErrors.jobTitleErr is defined %}
-                                {% for error in formErrors.jobTitleErr %}
+                            {% if formErrors.jobTitleErr is defined and formErrors.jobTitleErr.errors|length > 0 %}
+                                {% for error in formErrors.jobTitleErr.errors %}
                                     <span id="email-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                           
                             {% endif %} 
 
-                            <input class="govuk-input {{formErrors.jobTitleErr is defined ? 'govuk-input--error' : null }}" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text" value="{{formErrors is defined ? formData.jobTitle}}" autocomplete="organization-title"/>
+                            <input class="govuk-input {{formErrors.jobTitleErr is defined and formErrors.jobTitleErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text" value="{{formErrors is defined ? formData.jobTitle}}" autocomplete="organization-title"/>
                         </div>
-                        <div class="govuk-form-group govuk-!-width-one-half {{formErrors.postCodeErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group govuk-!-width-one-half {{formErrors.postCodeErr is defined and formErrors.postCodeErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="post-code">
                                 Organisation post code </label>
 
-                            {% if formErrors.postCodeErr is defined %}
-                                {% for error in formErrors.postCodeErr %}
+                            {% if formErrors.postCodeErr is defined and formErrors.postCodeErr.errors|length > 0 %}
+                                {% for error in formErrors.postCodeErr.errors %}
                                     <span id="email-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                           
                             {% endif %} 
 
-                            <input class="govuk-input {{formErrors.postCodeErr is defined ? 'govuk-input--error' : null }}" id="post-code" maxlength="100" name="post-code" size="20" type="text" value="{{formErrors is defined ? formData.postCode}}" autocomplete="postal-code"/>
+                            <input class="govuk-input {{formErrors.postCodeErr is defined and formErrors.postCodeErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="post-code" maxlength="100" name="post-code" size="20" type="text" value="{{formErrors is defined ? formData.postCode}}" autocomplete="postal-code"/>
                         </div>
 
 
@@ -281,12 +295,12 @@
                         </div>
 
 
-                        <div class="govuk-form-group {{formErrors.moreDetailErr is defined ? 'govuk-form-group--error' : null }}">
+                        <div class="govuk-form-group {{formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 ? 'govuk-form-group--error' : null }}">
                             <label id="more-detail-label" class="govuk-label" for="more-detail">Can
                                 you provide more detail?</label>
 
-                            {% if formErrors.moreDetailErr is defined %}
-                                {% for error in formErrors.moreDetailErr %}
+                            {% if formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 %}
+                                {% for error in formErrors.moreDetailErr.errors %}
                                     <span id="more-detail-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                      
                             {% endif %}
@@ -294,7 +308,7 @@
                             <span id="more-detail-hint" class="govuk-hint">
     Do not include personal or financial information, like your credit card details.
   </span>
-                            <textarea class="govuk-textarea {{formErrors.moreDetailErr is defined ? 'govuk-input--error' : null }}" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
+                            <textarea class="govuk-textarea {{formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
                         </div>
 
                         {# Catch-all field for additional Salesforce data #}
@@ -374,6 +388,12 @@
                             dataCollectionFieldForSalesforce.value += " " + fieldMoreDetail.name + ": " + fieldMoreDetail.value;
 
                         }, false);
+
+
+                        // if form errors exist reset focus to error summary
+                        if (document.title === 'Error: Contact Crown Commercial Services - CCS') {
+                            document.querySelector('.govuk-error-summary').focus();
+                        }
 
                     </script>
 

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}{{ formErrors is defined ? 'Error: Contact Crown Commercial Services - CCS' : 'Contact Crown Commercial Services - CCS'}}{% endblock %}
+{% block title %} Contact Crown Commercial Services - CCS {% endblock %}
 
 {% block header %}
     {% embed '/includes/header.html.twig' %}
@@ -398,7 +398,9 @@
 
 
                         // if form errors exist reset focus to error summary
-                        if (document.title === 'Error: Contact Crown Commercial Services - CCS') {
+                        var errorSummary = document.getElementsByClassName('govuk-error-summary');
+                        
+                        if (errorSummary.length > 0) {
                             document.querySelector('.govuk-error-summary').focus();
                         }
 

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -137,12 +137,12 @@
     </span>
                                 <div class="govuk-radios govuk-radios--conditional" data-module="radios">
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="how-contacted-conditional-1" name="origin" type="radio" value="Website - Enquiry" data-aria-controls="conditional-how-contacted-conditional-1" checked>
+                                        <input class="govuk-radios__input" id="how-contacted-conditional-1" name="origin" type="radio" value="Website - Enquiry" data-aria-controls="conditional-how-contacted-conditional-1" {{ formData is defined and formData.enquiryType is same as('Website - Complaint') ? null : 'checked' }}>
                                         <label class="govuk-label govuk-radios__label" for="how-contacted-conditional-1">
                                             General enquiry </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="how-contacted-conditional-2" name="origin" type="radio" value="Website - Complaint" data-aria-controls="conditional-how-contacted-conditional-2">
+                                        <input class="govuk-radios__input" id="how-contacted-conditional-2" name="origin" type="radio" value="Website - Complaint" data-aria-controls="conditional-how-contacted-conditional-2" {{ formData is defined and formData.enquiryType is same as('Website - Complaint') ? 'checked' : null }}>
                                         <label class="govuk-label govuk-radios__label" for="how-contacted-conditional-2">
                                             Feedback </label>
                                     </div>
@@ -206,7 +206,7 @@
                                 </legend>
                                 <div class="govuk-checkboxes">
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="00Nb0000009IXEg" name="00Nb0000009IXEg" type="checkbox" value="1"/>
+                                        <input class="govuk-checkboxes__input" id="00Nb0000009IXEg" name="00Nb0000009IXEg" type="checkbox" value="1" {{ formData.callback is defined ? 'checked' : null }}/>
                                         <label class="govuk-label govuk-checkboxes__label" for="00Nb0000009IXEg">
                                             Yes </label>
                                     </div>
@@ -275,17 +275,17 @@
                                     </legend>
                                     <div class="govuk-checkboxes">
                                         <div class="govuk-checkboxes__item">
-                                            <input class="govuk-checkboxes__input" id="complaint-1" name="complaint" type="checkbox" value="Service">
+                                            <input class="govuk-checkboxes__input" id="complaint-1" name="complaint" type="checkbox" value="Service" {{ formData.complaint is defined and formData.complaint is same as('Service') ? 'checked' : null }}>
                                             <label class="govuk-label govuk-checkboxes__label" for="complaint-1">
                                                 Service </label>
                                         </div>
                                         <div class="govuk-checkboxes__item">
-                                            <input class="govuk-checkboxes__input" id="complaint-2" name="complaint" type="checkbox" value="Supplier staff">
+                                            <input class="govuk-checkboxes__input" id="complaint-2" name="complaint" type="checkbox" value="Supplier staff" {{ formData.complaint is defined and formData.complaint is same as('Supplier staff') ? 'checked' : null }}>
                                             <label class="govuk-label govuk-checkboxes__label" for="complaint-2">
                                                 Supplier staff </label>
                                         </div>
                                         <div class="govuk-checkboxes__item">
-                                            <input class="govuk-checkboxes__input" id="complaint-3" name="complaint" type="checkbox" value="Other">
+                                            <input class="govuk-checkboxes__input" id="complaint-3" name="complaint" type="checkbox" value="Other" {{ formData.complaint is defined and formData.complaint is same as('Other') ? 'checked' : null }}>
                                             <label class="govuk-label govuk-checkboxes__label" for="complaint-3">
                                                 Other </label>
                                         </div>
@@ -346,6 +346,13 @@
                         condtionalFields = document.getElementById("conditional-fields");
                         generalEnquiryReturnURL = "{{ site_url }}/contact/thanks";
                         complaintReturnURL = "{{ site_url }}/contact/thanks-complaint";
+
+                        // if "Website - Complaint" is already selected for instance if there are errors and page has reloaded load additional fields
+                        if (document.getElementById('how-contacted-conditional-2').checked) {
+                                    retURLfield.value = complaintReturnURL;
+                                    condtionalFields.classList.remove("govuk-radios__conditional--hidden");
+                                    labelMoreDetail.textContent = "Briefly state your feedback:";
+                        }
 
                         for (var i = 0; i < fieldCheckboxes.length; i++) {
 

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -155,7 +155,7 @@
 
 
                         {# wrapper class for error states; `govuk-form-group--error`  #}
-                        <div class="govuk-form-group --govuk-form-group--error">
+                        <div class="govuk-form-group {{formErrors.nameErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="name">Name</label>
 
                             {% if formErrors.nameErr is defined %}
@@ -167,9 +167,9 @@
                             {#Descriptive and helpful error message#}
                             {#</span>
                             {# input class for error states; `govuk-input--error`  #}
-                            <input class="govuk-input --govuk-input--error" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text" value="{{formErrors is defined ? formData.name}}"/>
+                            <input class="govuk-input {{formErrors.nameErr is defined ? 'govuk-input--error' : null }}" aria-describedby="full-name-error" id="name" maxlength="80" name="name" size="20" type="text" value="{{formErrors is defined ? formData.name}}" autocomplete="name"/>
                         </div>
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {{formErrors.emailErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="email">
                                 Email </label>
 
@@ -179,7 +179,7 @@
                                 {% endfor %}                         
                             {% endif %}    
 
-                            <input class="govuk-input" id="email" maxlength="80" name="email" size="20" type="email" value="{{formErrors is defined ? formData.email}}" required/>
+                            <input class="govuk-input {{formErrors.emailErr is defined ? 'govuk-input--error' : null }}" id="email" maxlength="80" name="email" size="20" type="email" value="{{formErrors is defined ? formData.email}}" autocomplete="email" required/>
                         </div>
 
 
@@ -199,7 +199,7 @@
                                 </div>
                             </fieldset>
                         </div>
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {{formErrors.phoneErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="phone"> Telephone
                                 number</label>
 
@@ -209,11 +209,11 @@
                                 {% endfor %}                           
                             {% endif %}
 
-                            <input class="govuk-input" id="phone" maxlength="40" name="phone" size="20" type="text" value="{{formErrors is defined ? formData.phone}}" required/>
+                            <input class="govuk-input {{formErrors.phoneErr is defined ? 'govuk-input--error' : null }}" id="phone" maxlength="40" name="phone" size="20" type="text" value="{{formErrors is defined ? formData.phone}}" autocomplete="tel" required/>
                         </div>
 
 
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {{formErrors.companyErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="company">
                                 Organisation </label>
 
@@ -223,9 +223,9 @@
                                 {% endfor %}                            
                             {% endif %}   
 
-                            <input class="govuk-input" id="company" maxlength="80" name="company" size="20" type="text" value="{{formErrors is defined ? formData.company}}"/>
+                            <input class="govuk-input {{formErrors.companyErr is defined ? 'govuk-input--error' : null }}" id="company" maxlength="80" name="company" size="20" type="text" value="{{formErrors is defined ? formData.company}}" autocomplete="organization"/>
                         </div>
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {{formErrors.jobTitleErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="00Nb0000009IXEs">
                                 Job title </label>
 
@@ -235,9 +235,9 @@
                                 {% endfor %}                           
                             {% endif %} 
 
-                            <input class="govuk-input" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text" value="{{formErrors is defined ? formData.jobTitle}}"/>
+                            <input class="govuk-input {{formErrors.jobTitleErr is defined ? 'govuk-input--error' : null }}" id="00Nb0000009IXEs" maxlength="100" name="00Nb0000009IXEs" size="20" type="text" value="{{formErrors is defined ? formData.jobTitle}}" autocomplete="organization-title"/>
                         </div>
-                        <div class="govuk-form-group govuk-!-width-one-half">
+                        <div class="govuk-form-group govuk-!-width-one-half {{formErrors.postCodeErr is defined ? 'govuk-form-group--error' : null }}">
                             <label class="govuk-label" for="post-code">
                                 Organisation post code </label>
 
@@ -247,7 +247,7 @@
                                 {% endfor %}                           
                             {% endif %} 
 
-                            <input class="govuk-input" id="post-code" maxlength="100" name="post-code" size="20" type="text" value="{{formErrors is defined ? formData.postCode}}"/>
+                            <input class="govuk-input {{formErrors.postCodeErr is defined ? 'govuk-input--error' : null }}" id="post-code" maxlength="100" name="post-code" size="20" type="text" value="{{formErrors is defined ? formData.postCode}}" autocomplete="postal-code"/>
                         </div>
 
 
@@ -281,7 +281,7 @@
                         </div>
 
 
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {{formErrors.moreDetailErr is defined ? 'govuk-form-group--error' : null }}">
                             <label id="more-detail-label" class="govuk-label" for="more-detail">Can
                                 you provide more detail?</label>
 
@@ -290,11 +290,11 @@
                                     <span id="more-detail-error" class="govuk-error-message">{{error}}</span>
                                 {% endfor %}                      
                             {% endif %}
-                            
+
                             <span id="more-detail-hint" class="govuk-hint">
     Do not include personal or financial information, like your credit card details.
   </span>
-                            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
+                            <textarea class="govuk-textarea {{formErrors.moreDetailErr is defined ? 'govuk-input--error' : null }}" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
                         </div>
 
                         {# Catch-all field for additional Salesforce data #}

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -46,7 +46,7 @@
         <main id="main-content" role="main" class="govuk-main-wrapper">
 
             {% if formErrors is defined %}
-            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+            <div class="govuk-error-summary govuk-grid-column-three-quarters" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
                 <h2 class="govuk-error-summary__title" id="error-summary-title"> There is a problem</h2>
                 <div class="govuk-error-summary__body">
                     <ul class="govuk-list govuk-error-summary__list">
@@ -308,7 +308,7 @@
                             <span id="more-detail-hint" class="govuk-hint">
     Do not include personal or financial information, like your credit card details.
   </span>
-                            <textarea class="govuk-textarea {{formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 ? 'govuk-input--error' : null }}" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
+                            <textarea class="govuk-textarea" style="{{formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 ? 'border: 4px solid #b10e1e' : null }}" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint" required>{{formErrors is defined ? formData.moreDetail}}</textarea>
                         </div>
 
                         {# Catch-all field for additional Salesforce data #}

--- a/templates/forms/22-contact.html.twig
+++ b/templates/forms/22-contact.html.twig
@@ -174,7 +174,9 @@
 
                             {% if formErrors.nameErr is defined and formErrors.nameErr.errors|length > 0 %}
                                 {% for error in formErrors.nameErr.errors %}
-                                    <span id="full-name-error" class="govuk-error-message">{{error}}</span>
+                                     <span id="full-name-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                     </span>
                                 {% endfor %}
                             {% endif %}
 
@@ -189,7 +191,9 @@
 
                             {% if formErrors.emailErr is defined and formErrors.emailErr.errors|length > 0 %}
                                 {% for error in formErrors.emailErr.errors %}
-                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="email-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                         
                             {% endif %}    
 
@@ -219,7 +223,9 @@
 
                             {% if formErrors.phoneErr is defined and formErrors.phoneErr.errors|length > 0 %}
                                 {% for error in formErrors.phoneErr.errors %}
-                                    <span id="phone-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="phone-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                           
                             {% endif %}
 
@@ -233,7 +239,9 @@
 
                             {% if formErrors.companyErr is defined and formErrors.companyErr.errors|length > 0 %}
                                 {% for error in formErrors.companyErr.errors %}
-                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="company-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                            
                             {% endif %}   
 
@@ -245,7 +253,9 @@
 
                             {% if formErrors.jobTitleErr is defined and formErrors.jobTitleErr.errors|length > 0 %}
                                 {% for error in formErrors.jobTitleErr.errors %}
-                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="job-title-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                           
                             {% endif %} 
 
@@ -257,7 +267,9 @@
 
                             {% if formErrors.postCodeErr is defined and formErrors.postCodeErr.errors|length > 0 %}
                                 {% for error in formErrors.postCodeErr.errors %}
-                                    <span id="email-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="post-code-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                           
                             {% endif %} 
 
@@ -301,7 +313,9 @@
 
                             {% if formErrors.moreDetailErr is defined and formErrors.moreDetailErr.errors|length > 0 %}
                                 {% for error in formErrors.moreDetailErr.errors %}
-                                    <span id="more-detail-error" class="govuk-error-message">{{error}}</span>
+                                    <span id="more-detail-error" class="govuk-error-message">
+                                        <span class="govuk-visually-hidden">Error:</span>{{error}}
+                                    </span>
                                 {% endfor %}                      
                             {% endif %}
 
@@ -399,7 +413,7 @@
 
                         // if form errors exist reset focus to error summary
                         var errorSummary = document.getElementsByClassName('govuk-error-summary');
-                        
+
                         if (errorSummary.length > 0) {
                             document.querySelector('.govuk-error-summary').focus();
                         }


### PR DESCRIPTION
These changes only apply to the contact form for now as the form action was only changed for this form to go to the controller. 

Changes to controller

- Added a check in the sendToSalesForce function to check for form errors. If there are no errors then form will be sent as normal to salesforce
- validateForm function which has various checks for validation depending on the field. 

Changes to contactform.html.twig

- Added twig conditionals to check for form errors and display span errors if there are any as per GDS standards
- Added error summary with errors and links to the appropriate fields as per GDS standards
- Changed page title depending on if there are any errors as per GDS standards
-  Inline JavaScript check to reset focus to error summary as per GDS standards

for ref - https://design-system.service.gov.uk/components/error-summary/


<img width="1389" alt="Screenshot 2020-09-11 at 12 23 19" src="https://user-images.githubusercontent.com/69308726/92920319-00f3c180-f42a-11ea-8aa2-e1a6efd8916b.png">
<img width="555" alt="Screenshot 2020-09-11 at 12 25 42" src="https://user-images.githubusercontent.com/69308726/92920323-03561b80-f42a-11ea-8439-d02977dd0fb5.png">
