### PR TITLE
Fix for spacing issue between banner and content

### DIFF
--- a/templates/pages/page.html.twig
+++ b/templates/pages/page.html.twig
@@ -119,11 +119,10 @@
 
                     <div class="page-components">
                         {% include '_components/components.html.twig' with {'components': page.content.page_components_rows } %}
-                        
+
                         {% if page.content.brochures_list_brochures_list is not empty  or  page.content.whitepapers_list_whitepapers is not empty  or  page.content.webinars_list_webinars is not empty %}
                             {% include '_components/resources-section.html.twig' %}
                         {% endif %}
-
                     </div>
 
 

--- a/templates/pages/page.html.twig
+++ b/templates/pages/page.html.twig
@@ -119,8 +119,11 @@
 
                     <div class="page-components">
                         {% include '_components/components.html.twig' with {'components': page.content.page_components_rows } %}
+                        
+                        {% if page.content.brochures_list_brochures_list is not empty  or  page.content.whitepapers_list_whitepapers is not empty  or  page.content.webinars_list_webinars is not empty %}
+                            {% include '_components/resources-section.html.twig' %}
+                        {% endif %}
 
-                        {% include '_components/resources-section.html.twig' %}
                     </div>
 
 


### PR DESCRIPTION
This fix is for the issue with spacing between the hero banner and form. 

- The cause of this issue related to the component/resources-section.html.twig file which has the code for the page resources (this is a section on wordpress(see screenshot)) component template. This file contains an parent div ('component resources-section) which has some extra margin at the top and bottom. 
- I have added a conditional which checks to see if there is any content in the page resources section. If there is the component is displayed if not then it is not shown hence removing the margin and spacing and fixing the issue.

**Note:** this will also change the template for other pages that do not have the page resources content but as discussed this shouldn't be an issue.  

<img width="1003" alt="Screenshot 2020-10-22 at 16 37 50" src="https://user-images.githubusercontent.com/69308726/96896287-3ce86080-1485-11eb-86a0-941048f956cb.png">
