### PR TITLE
Web 1449 remove hardcoding upcoming deals

### DIFF
--- a/src/Controller/FrameworksController.php
+++ b/src/Controller/FrameworksController.php
@@ -10,6 +10,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Studio24\Frontend\Cms\RestData;
 use GuzzleHttp\Client;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpClient\HttpClient;
 use Studio24\Frontend\Exception\NotFoundException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
@@ -177,12 +178,28 @@ class FrameworksController extends AbstractController
             throw new NotFoundHttpException('Page not found', $e);
         }
 
+         // request to upcoming deals information api for titles and description
+         $upcomingDealsUrl = getenv('APP_API_BASE_URL') . 'ccs/v1/upcoming-deals-page/0';
+
+         $client = HttpClient::create();
+         $response = $client->request(
+             'GET',
+             $upcomingDealsUrl,
+         );
+ 
+         $upcomingDealsContent = null;
+ 
+         if ($response->getStatusCode() == 200) {
+             $upcomingDealsContent = json_decode($response->getContent());
+         }
+
         $data = [
             'awarded_pipeline'              => $results->getContent()->get('awarded_pipeline'),
             'underway_pipeline'             => $results->getContent()->get('underway_pipeline'),
             'dynamic_purchasing_systems'    => $results->getContent()->get('dynamic_purchasing_systems'),
             'planned_pipeline'              => $results->getContent()->get('planned_pipeline'),
             'future_pipeline'               => $results->getContent()->get('future_pipeline'),
+            'upcoming_deals_content'        => $upcomingDealsContent,
         ];
 
         return $this->render('frameworks/upcoming-list.html.twig', $data);

--- a/src/Controller/FrameworksController.php
+++ b/src/Controller/FrameworksController.php
@@ -186,12 +186,12 @@ class FrameworksController extends AbstractController
              'GET',
              $upcomingDealsUrl,
          );
- 
+
          $upcomingDealsContent = null;
- 
-         if ($response->getStatusCode() == 200) {
-             $upcomingDealsContent = json_decode($response->getContent());
-         }
+
+        if ($response->getStatusCode() == 200) {
+            $upcomingDealsContent = json_decode($response->getContent());
+        }
 
         $data = [
             'awarded_pipeline'              => $results->getContent()->get('awarded_pipeline'),

--- a/templates/frameworks/upcoming-list.html.twig
+++ b/templates/frameworks/upcoming-list.html.twig
@@ -52,11 +52,21 @@
                 <div class="govuk-grid-column-full">
 
 
+                    {% if upcoming_deals_content and upcoming_deals_content.upcomingDealsInfo.title and upcoming_deals_content.upcomingDealsInfo.page_description  %}
 
-                    <h1 class="govuk-heading-xl page-title">Upcoming deals</h1>
+                        <h1 class="govuk-heading-xl page-title">{{upcoming_deals_content.upcomingDealsInfo.title}}</h1>
 
-                    <p class="govuk-body-l govuk-!-width-three-quarters">If you would like to find out more about the scope of any of these procurements please
-                        <a href="/contact">contact us</a>.</p>
+                        {# raw html #}
+                        {{upcoming_deals_content.upcomingDealsInfo.page_description | raw }}
+
+                    {% else %}
+
+                        <h1 class="govuk-heading-xl page-title">Upcoming Deals</h1>
+
+                        <p class="govuk-body-l govuk-!-width-three-quarters">If you would like to find out more about the scope of any of these procurements please
+                            <a href="/contact">contact us</a>.</p>
+
+                    {% endif %}
 
 
 
@@ -68,10 +78,16 @@
                     {#{{ dump(planned_pipeline) }}#}
                     {#{{ dump(future_pipeline) }}#}
 
+                    {% if upcoming_deals_content and upcoming_deals_content.table_0.title %}
 
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">{{ upcoming_deals_content.table_0.title }}</h2>
 
-                    <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Procurements recently awarded</h2>
+                    {% else %}
 
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Procurements recently awarded</h2>
+
+                    {% endif %}
+                    
                     {% if awarded_pipeline|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
@@ -129,14 +145,31 @@
                     {% endif %}
 
 
+                    {% if upcoming_deals_content and upcoming_deals_content.table_1.title %}
 
-                    <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Procurements in progress</h2>
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">{{ upcoming_deals_content.table_1.title }}</h2>
+
+                    {% else %}
+
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Procurements in progress</h2>
+
+                    {% endif %}
 
                     {% if underway_pipeline|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
-                            <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">The links provided in the agreement section below give further information about the procurement, including the OJEU notice and details on how to tender for interested suppliers.
-                            </caption>
+
+                            {% if upcoming_deals_content and upcoming_deals_content.table_1.caption %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">{{ upcoming_deals_content.table_1.caption }}</caption>
+
+                            {% else %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">The links provided in the agreement section below give further information about the procurement, including the OJEU notice and details on how to tender for interested suppliers.
+                                </caption>
+
+                            {% endif %}
+
                             <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header govuk-!-font-size-19 govuk-!-width-one-quarter" scope="col">
@@ -194,8 +227,15 @@
 
 
 
+                    {% if upcoming_deals_content and upcoming_deals_content.table_2.title %}
 
-                    <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Dynamic Purchasing Systems currently open</h2>
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">{{ upcoming_deals_content.table_2.title }}</h2>
+
+                    {% else %}
+
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Dynamic Purchasing Systems currently open</h2>
+
+                    {% endif %}
 
                     {% if dynamic_purchasing_systems|length >= 1 %}
 
@@ -252,8 +292,15 @@
 
 
 
+                    {% if upcoming_deals_content and upcoming_deals_content.table_3.title %}
 
-                    <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Planned procurements</h2>
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">{{ upcoming_deals_content.table_3.title }}</h2>
+
+                    {% else %}
+
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Planned procurements</h2>
+
+                    {% endif %}
 
                     {% if planned_pipeline|length >= 1 %}
 
@@ -317,8 +364,15 @@
 
 
 
+                    {% if upcoming_deals_content and upcoming_deals_content.table_4.title %}
 
-                    <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Future pipeline</h2>
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">{{ upcoming_deals_content.table_4.title }}</h2>
+
+                    {% else %}
+
+                        <h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-24 govuk-!-font-weight-bold">Future pipeline</h2>
+
+                    {% endif %}
 
                     {% if future_pipeline|length >= 1 %}
 

--- a/templates/frameworks/upcoming-list.html.twig
+++ b/templates/frameworks/upcoming-list.html.twig
@@ -91,8 +91,12 @@
                     {% if awarded_pipeline|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
-                            {#<caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">Describe a table in the same way you would use a heading. A caption helps users find, navigate and understand tables.#}
-                            {#</caption>#}
+                            {% if upcoming_deals_content and upcoming_deals_content.table_0.caption|length > 0 %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">{{ upcoming_deals_content.table_0.caption }}</caption>
+
+                            {% endif %}
+
                             <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header govuk-!-font-size-19 govuk-!-width-one-quarter" scope="col">
@@ -240,8 +244,12 @@
                     {% if dynamic_purchasing_systems|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
-                            {#<caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">Describe a table in the same way you would use a heading. A caption helps users find, navigate and understand tables.#}
-                            {#</caption>#}
+                            {% if upcoming_deals_content and upcoming_deals_content.table_2.caption|length > 0 %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">{{ upcoming_deals_content.table_2.caption }}</caption>
+
+                            {% endif %}
+
                             <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header govuk-!-font-size-19 govuk-!-width-one-quarter" scope="col">
@@ -305,8 +313,13 @@
                     {% if planned_pipeline|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
-                            {#<caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">Describe a table in the same way you would use a heading. A caption helps users find, navigate and understand tables.#}
-                            {#</caption>#}
+
+                            {% if upcoming_deals_content and upcoming_deals_content.table_3.caption|length > 0 %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">{{ upcoming_deals_content.table_3.caption }}</caption>
+
+                            {% endif %}
+
                             <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header govuk-!-font-size-19 govuk-!-width-one-quarter" scope="col">
@@ -377,8 +390,13 @@
                     {% if future_pipeline|length >= 1 %}
 
                         <table class="govuk-table ccs-table--upcoming-deals">
-                            {#<caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">Describe a table in the same way you would use a heading. A caption helps users find, navigate and understand tables.#}
-                            {#</caption>#}
+
+                            {% if upcoming_deals_content and upcoming_deals_content.table_4.caption|length > 0 %}
+
+                                <caption class="govuk-table__caption govuk-!-font-size-19 govuk-!-font-weight-regular">{{ upcoming_deals_content.table_4.caption }}</caption>
+
+                            {% endif %}
+
                             <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header govuk-!-font-size-19 govuk-!-width-one-quarter" scope="col">


### PR DESCRIPTION
This is the view for upcoming deals. Please note the backend (wordpress) needs to be set in order for this to work