### PR TITLE
show author name on blog/news/case

### DIFF
--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -85,7 +85,7 @@ class NewsController extends AbstractController
 
         try {
             $page = $this->api->getPageByUrl($request->getRequestUri());
-            $response = HttpClient::create()->request('GET',getenv('APP_API_BASE_URL') . 'wp/v2/posts/' . $page->getId());
+            $response = HttpClient::create()->request('GET', getenv('APP_API_BASE_URL') . 'wp/v2/posts/' . $page->getId());
 
             if ($response->getStatusCode() == 200) {
                 $authorName = json_decode($response->getContent())->authorName;

--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -12,6 +12,7 @@ use Studio24\Frontend\Exception\PaginationException;
 use Studio24\Frontend\Exception\WordpressException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpClient\HttpClient;
 use Studio24\Frontend\Exception\NotFoundException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -84,13 +85,19 @@ class NewsController extends AbstractController
 
         try {
             $page = $this->api->getPageByUrl($request->getRequestUri());
+            $response = HttpClient::create()->request('GET',getenv('APP_API_BASE_URL') . 'wp/v2/posts/' . $page->getId());
+
+            if ($response->getStatusCode() == 200) {
+                $authorName = json_decode($response->getContent())->authorName;
+            }
         } catch (NotFoundException $e) {
             throw new NotFoundHttpException('News page not found', $e);
         }
 
         return $this->render('news/show.html.twig', [
-            'url' => sprintf('/news/%s', $slug),
-            'page' => $page
+            'url'           => sprintf('/news/%s', $slug),
+            'page'          => $page,
+            'authorName'    => $authorName
         ]);
     }
 

--- a/templates/news/show.html.twig
+++ b/templates/news/show.html.twig
@@ -92,6 +92,18 @@
                 {# End of wysiwyg content #}
 
 
+                <div class="news-listing-meta--featured">
+                    {% if page.taxonomies.categories %}
+                        {% for category in page.taxonomies.categories %}
+                            {{ category.name }}{% if loop.index < page.taxonomies.categories|length %}, {% endif %}
+                        {% endfor %}
+                    {% endif %}
+                    | {{ page.datePublished|date('jS F Y') }}
+                    {% if authorName != null %}
+                        | Written by {{authorName}}
+                    {% endif %}
+                </div>
+
 
                 <div class="app-c-print-link">
                     <button onclick="window.print();" type="button" class="app-c-print-link__link" rel="alternate">Print this page</button>


### PR DESCRIPTION
The reason that we have to go through the API again is that we cannot modify the studio24 frontend part to take in the additional value that I have added to WordPress.