### PR TITLE
output correct env in JS

### DIFF
--- a/assets/scripts/dataLayer.js
+++ b/assets/scripts/dataLayer.js
@@ -107,10 +107,11 @@ function fileDownload( fileURL, fileName, fileSize) {
 
 }
 
-function pushToDataLayer(array){
-    array = (typeof array === 'string')? JSON.parse(array) : array;
+function pushToDataLayer(array) {
+    array = (typeof array === 'string') ? JSON.parse(array) : array;
+    var env = document.getElementById('app-env').dataset.env;
 
-    if ('{{ app.environment }}' == "local" || '{{ app.environment }}' == "prod") {
+    if (env == "local" || env == "prod") {
         window.dataLayer.push(array);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -179,6 +179,9 @@
 #}
 <body class="govuk-template__body {% block flourishClasses %}show-flourishes  {{ taxonomy }}--{{ flourish }}{% endblock %}">
 
+{# For data layer - outputs environment to be used in js file #}
+<div id="app-env" style="display: none" data-env="local"></div>
+
 {{ staging_banner(app.environment) }}
 
 {# Google Tag Manager (noscript) THIS SHOULD BE REMOVED IF EXPLICIT OPT-IN is used #}


### PR DESCRIPTION
@Chee-Ng Will leave for you decide to hotfix next week or push into next deployement. Basically app.environment wasn't outputting anthing in JS so had to create an empty element in HTML file in order to push to JS file. 