### PR TITLE
Add critical CSS as fallback

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -47,6 +47,16 @@
 
     {% block pageMetaTags %}{{ (page is defined)? page.head.getAllMetaHtml()|raw : '' }}{% endblock %}
 
+    <style>
+    
+        :root {
+        --govuk-frontend-version: "5.4.0";
+        --govuk-frontend-breakpoint-mobile: 20rem;
+        --govuk-frontend-breakpoint-tablet: 40.0625rem;
+        --govuk-frontend-breakpoint-desktop: 48.0625rem; 
+        }
+    </style>
+
     {% if app.environment == "prod" %}
          <link rel="preload" href="/assets/styles/styles.min.css?v=1.71" as="style" onload="this.onload=null;this.rel='stylesheet'">
         <noscript><link rel="stylesheet" href="/assets/styles/styles.min.css?v=1.71"></noscript>


### PR DESCRIPTION
The underlying cause for this was a js function within govuk frontend package not being able to detect the 'root' selector. This is because of the way CSS is now loaded asynchronously. 

This hopefully mitigates this by loading in that selector immediately in the HTML.  